### PR TITLE
Allow for custom headers in file upload.

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,9 +16,13 @@ exports.fromKnox = function(knoxClient) {
 
 function Client(options) {}
 
-Client.prototype.upload = function(localFile, remoteFile) {
+Client.prototype.upload = function(localFile, remoteFile, headers) {
+  
+  if (typeof headers != 'object')
+    headers = { };
+  
   var uploader = new EventEmitter();
-  var knoxUpload = this.knox.putFile(localFile, remoteFile, function (err, resp) {
+  var knoxUpload = this.knox.putFile(localFile, remoteFile, headers, function (err, resp) {
     if (err) {
       uploader.emit('error', err);
     } else if (resp.statusCode === 200) {


### PR DESCRIPTION
The underlying `knox` module allows for custom headers to be passed through to the `putFile` function. I'm using `node-s3-client` because it encapsulates the `fs` related functionality, but I also need the custom headers. The unit tests still pass.

Now you can do something like this:

``` javascript
var uploader = s3.upload(source, destination, { 'x-amz-acl': 'public-read' });
```
