### PR TITLE
Adding default MimeType guessing for uploadDir.

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,8 @@ Syncs an entire directory to S3.
  * `getS3Params` - optional function which will be called for every file that
    needs to be uploaded. See below.
  * `followSymlinks` - defaults to `false`
+ * `guessMimeType` - this will be over-written if you specify a s3Params.ContentType with the getS3Params function listed below.
+   default true
  * `s3Params`
    - `Prefix` (required)
    - `Bucket` (required)

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,7 @@ var Pend = require('pend');
 var path = require('path');
 var crypto = require('crypto');
 var mkdirp = require('mkdirp');
+var mime = require('mime');
 var assert = require('assert');
 var MultipartETag = require('./multipart_etag');
 var FdSlicer = require('fd-slicer');
@@ -741,6 +742,7 @@ function syncDir(self, params, directionIsToS3) {
   var fatalError = false;
   var prefix = params.s3Params.Prefix ? ensureSlash(params.s3Params.Prefix) : '';
   var bucket = params.s3Params.Bucket;
+  var guessMimeType = (typeof params.guessMimeType === "boolean") ? params.guessMimeType : true; 
   var listObjectsParams = {
     recursive: true,
     s3Params: {
@@ -987,6 +989,11 @@ function syncDir(self, params, directionIsToS3) {
       }
 
       function startUpload() {
+        // Check for Default MimeType
+        var fullPath = path.join(localDir, localFileStat.path);
+        if (guessMimeType && typeof upDownFileParams.s3Params.ContentType !== "string") {
+          upDownFileParams.s3Params.ContentType = mime.lookup(fullPath);
+        }
         ee.progressTotal += localFileStat.size;
         upDownFileParams.s3Params.Key = prefix + localFileStat.s3Path;
         upDownFileParams.localFile = fullPath;

--- a/package.json
+++ b/package.json
@@ -35,12 +35,13 @@
   },
   "dependencies": {
     "aws-sdk": "~2.0.12",
+    "fd-slicer": "~0.1.0",
     "findit": "~2.0.0",
     "graceful-fs": "~3.0.2",
+    "mime": "^1.2.11",
     "mkdirp": "~0.5.0",
     "pend": "~1.1.2",
-    "rimraf": "~2.2.8",
-    "fd-slicer": "~0.1.0"
+    "rimraf": "~2.2.8"
   },
   "bugs": {
     "url": "https://github.com/andrewrk/node-s3-client/issues"


### PR DESCRIPTION
Hey so a friend of mine spent a couple hours banging his head against his keyboard because he didn't realize that MimeTypes weren't automatically being set. I know you have your cli which does this, but I figured since this client seems fairly popular you could add MimeType guessing as a default which is easily over-writeable...

I'm just sitting here next to him, so I haven't actually set up an AWS instance in order to test, but I think my code was decent. If you let me know, I can try to fix stuff.

Thanks!
