### PR TITLE
Download with deleteRemoved option should not delete subdirectory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1152,6 +1152,9 @@ function syncDir(self, params, directionIsToS3) {
       ee.objectsFound += data.Contents.length;
       ee.emit('progress');
       data.Contents.forEach(function(object) {
+        if (object.Key === prefix) {
+          return;
+        }
         object.key = object.Key.substring(prefix.length);
         allS3Objects.push(object);
       });


### PR DESCRIPTION
Fixes #54

To sum it up, when you try to download a remote directory called `remote-dir` from a bucket, and specify the local directory as `local-dir`, I would expect just the contents of `remote-dir` to download, not the directory itself, so `remote-dir/` shouldn't need to be pushed to `allS3Objects` when listing remote objects, but it is right now.

If `local-dir` has a subdirectory called `foo` (valid directory that also exists remotely and thus should be retained), it will get deleted on the next download attempt. Because of the extra `remote-dir/` entry in `allS3Objects`, when you start diff'ing the remote objects against the local ones, you end up checking if the string `foo/` is contained within the `remote-dir/` s3Object.key string, which is an empty string after the [prefix truncation](https://github.com/andrewrk/node-s3-client/blob/4.3.1/lib/index.js#L1154). And since it isn't, [`deleteLocalDir()`](https://github.com/andrewrk/node-s3-client/blob/4.3.1/lib/index.js#L953) gets called.
