### PR TITLE
fix for no content-length in header for download

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -460,47 +460,67 @@ Client.prototype.downloadFile = function(params) {
       if (statusCode >= 300) {
         handleError(new Error("http status code " + statusCode));
         return;
-      }
-      var contentLength = parseInt(headers['content-length'], 10);
-      downloader.progressTotal = contentLength;
-      downloader.progressAmount = 0;
-      downloader.emit('progress');
-      downloader.emit('httpHeaders', statusCode, headers, resp);
-      var eTag = cleanETag(headers.etag);
-      var eTagCount = getETagCount(eTag);
+      } 
+      if (headers['content-length'] == undefined) {
+        var outStream = fs.createWriteStream(localFile);
+        outStream.on('error', handleError);
+        downloader.progressTotal = 0
+        downloader.progressAmount = -1;
+        request.on('httpData', function(chunk) {
+          downloader.progressTotal += chunk.length;
+          downloader.progressAmount += chunk.length;
+          downloader.emit('progress');
+          outStream.write(chunk); 
+        })
 
-      var outStream = fs.createWriteStream(localFile);
-      var multipartETag = new MultipartETag({size: contentLength, count: eTagCount});
-      var httpStream = resp.httpResponse.createUnbufferedStream();
-
-      httpStream.on('error', handleError);
-      outStream.on('error', handleError);
-
-      hashCheckPend.go(function(cb) {
-        multipartETag.on('end', function() {
-          if (multipartETag.bytes !== contentLength) {
-            handleError(new Error("Downloaded size does not match Content-Length"));
-            return;
-          }
-          if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
-            handleError(new Error("ETag does not match MD5 checksum"));
-            return;
-          }
-          cb();
-        });
-      });
-      multipartETag.on('progress', function() {
-        downloader.progressAmount = multipartETag.bytes;
+        request.on('httpDone', function() { 
+          if (errorOccurred) return;
+          downloader.progressAmount += 1;
+          downloader.emit('progress');
+          outStream.end(); 
+        })
+      } else {
+        var contentLength = parseInt(headers['content-length'], 10);
+        downloader.progressTotal = contentLength;
+        downloader.progressAmount = 0;
         downloader.emit('progress');
-      });
-      outStream.on('close', function() {
-        if (errorOccurred) return;
-        hashCheckPend.wait(cb);
-      });
+        downloader.emit('httpHeaders', statusCode, headers, resp);
+        var eTag = cleanETag(headers.etag);
+        var eTagCount = getETagCount(eTag);
 
-      httpStream.pipe(multipartETag);
-      httpStream.pipe(outStream);
-      multipartETag.resume();
+        var outStream = fs.createWriteStream(localFile);
+        var multipartETag = new MultipartETag({size: contentLength, count: eTagCount});
+        var httpStream = resp.httpResponse.createUnbufferedStream();
+
+        httpStream.on('error', handleError);
+        outStream.on('error', handleError);
+
+        hashCheckPend.go(function(cb) {
+          multipartETag.on('end', function() {
+            if (multipartETag.bytes !== contentLength) {
+              handleError(new Error("Downloaded size does not match Content-Length"));
+              return;
+            }
+            if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
+              handleError(new Error("ETag does not match MD5 checksum"));
+              return;
+            }
+            cb();
+          });
+        });
+        multipartETag.on('progress', function() {
+          downloader.progressAmount = multipartETag.bytes;
+          downloader.emit('progress');
+        });
+        outStream.on('close', function() {
+          if (errorOccurred) return;
+          hashCheckPend.wait(cb);
+        });
+
+        httpStream.pipe(multipartETag);
+        httpStream.pipe(outStream);
+        multipartETag.resume();
+      }
     });
 
     request.send(handleError);

--- a/lib/index.js
+++ b/lib/index.js
@@ -478,6 +478,7 @@ Client.prototype.downloadFile = function(params) {
           downloader.progressAmount += 1;
           downloader.emit('progress');
           outStream.end(); 
+          cb();
         })
       } else {
         var contentLength = parseInt(headers['content-length'], 10);

--- a/test/test.js
+++ b/test/test.js
@@ -36,6 +36,7 @@ function createClient() {
     s3Options: {
       accessKeyId: process.env.S3_KEY,
       secretAccessKey: process.env.S3_SECRET,
+      endpoint: process.env.S3_ENDPOINT,
     },
   });
 }


### PR DESCRIPTION
When using a 3rd party S3 storage service (not AWS) there are instances when the server returns a header without ‘content-length’. This makes anything specifying `content-length` in `doTheDownload` function fail. After troubleshooting, some 3rd party S3 services specify `transfer-encoding: chunked`. 
```
{ date: 'Fri, 06 Feb 2015 20:18:09 GMT',
  server: 'ViPR/1.0',
  'x-amz-request-id': '0a6c5fc3:14af4ae3238:f7f1:b',
  'x-amz-id-2': '97e9f1ba70052a7b85e9db09cd13f09454828f6f0a5b92e5f691c07656a7ec10',
  etag: '"e1f0060d53cbfab7f917642abaa7a1c6"',
  'last-modified': 'Fri, 06 Feb 2015 16:09:15 GMT',
  'x-emc-mtime': '1423238955945',
  'content-type': 'application/zip',
  'transfer-encoding': 'chunked' }
```
This workaround will repeat some of the code after verifying that the `content-length == undefined`. This will create a writeable stream to save a file, while still emitting progress. The `downloader.progressTotal` will be the `chunk.length`, while the `downloader.progressAmount` will be `chunk.length -1`. This keeps the total below completion(ie 99%). It's impossible to know the complete size because the `content-length` is not specified. When the transfer ends, +1 is added to `downloader.progressAmount` to be complete at 100%.