### PR TITLE
Update to latest `aws-sdk`

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ncp": "~1.0.1"
   },
   "dependencies": {
-    "aws-sdk": "~2.0.31",
+    "aws-sdk": "~2.2.16",
     "fd-slicer": "~1.0.0",
     "findit2": "~2.2.3",
     "graceful-fs": "~3.0.5",


### PR DESCRIPTION
→ Fixes issue with not being able to set Cloudfront `DistributionConfig.Origins.Items[x].OriginPath`. Previous `aws-sdk` would throw an "unexpected argument" error on `OriginPath`