### PR TITLE
Update upload code to work correctly for 1MB+ files and AWS 2.1.1+

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -270,7 +270,6 @@ Client.prototype.uploadFile = function(params) {
           if (fatalError || errorOccurred) return;
           handleError(err);
         });
-        s3Params.Body = inStream;
         s3Params.ContentLength = end - start;
         s3Params.PartNumber = part.PartNumber;
         s3Params.UploadId = uploadId;
@@ -297,7 +296,7 @@ Client.prototype.uploadFile = function(params) {
           haveETag();
         });
         inStream.pipe(multipartETag);
-        multipartETag.resume();
+        s3Params.Body = multipartETag;
 
         self.s3.uploadPart(extend({}, s3Params), function(err, data) {
           pendCb();
@@ -392,11 +391,11 @@ Client.prototype.uploadFile = function(params) {
         uploader.progressAmount = multipartETag.bytes;
         uploader.emit('progress');
       });
-      s3Params.Body = inStream;
       s3Params.ContentLength = localFileStat.size;
       uploader.progressAmount = 0;
       inStream.pipe(multipartETag);
-      multipartETag.resume();
+      s3Params.Body = multipartETag;
+      
       self.s3.putObject(s3Params, function(err, data) {
         pendCb();
         if (fatalError) return;

--- a/lib/multipart_etag.js
+++ b/lib/multipart_etag.js
@@ -69,7 +69,7 @@ MultipartETag.prototype._transform = function(chunk, encoding, callback) {
     }
   }
   this.emit('progress');
-  callback();
+  callback(null, chunk);
 };
 
 MultipartETag.prototype._flush = function(callback) {


### PR DESCRIPTION
### Change Summary
With the introduction of AWS sdk 2.1.1 two of the unit tests are broken.  This update chains the s3Params.body to the MD5 hash generation (MultipartETag) to the inStream allowing the code to handle latency in reading from the input stream introduced by waiting for a response from AWS.

### Change details
Since we are calling inStream.pipe(multipartETag) this puts the stream into flow-mode where data will being flowing on the next tick. With files larger than 1MB AWS waits for an Expect response from the server before calling .pipe on the body stream. With the added latency most (if not all) the data is already read from the inStream pipe by the time AWS gets around to reading from it.

The cleanest fix would seem to be changing the MultipartETag class to be a pass-through stream (it is already 99.9% like this) and then setting this stream in the s3Params.body property. Another fix would be to call .pause() on the inStream but that relies on implicit .pipe() behavior turning the stream back into flow-mode and on AWS implementation details (that they are currently calling .pipe()).