### PR TITLE
End Sync Only When Transfers Have Ended

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -940,6 +940,7 @@ function syncDir(self, params, directionIsToS3) {
   };
   delete upDownFileParams.s3Params.Prefix;
 
+  ee.activeTransfers = 0;
   ee.progressAmount = 0;
   ee.progressTotal = 0;
   ee.progressMd5Amount = 0;
@@ -1006,7 +1007,8 @@ function syncDir(self, params, directionIsToS3) {
       // if we don't have any pending deletes or uploads, we're actually done
       flushDeletes();
       if (ee.deleteAmount >= ee.deleteTotal &&
-          ee.progressAmount >= ee.progressTotal)
+          ee.progressAmount >= ee.progressTotal &&
+          ee.activeTransfers === 0)
       {
         ee.emit('end');
         // prevent checkDoMoreWork from doing any more work
@@ -1124,6 +1126,7 @@ function syncDir(self, params, directionIsToS3) {
         upDownFileParams.localFile = fullPath;
         var downloader = self.downloadFile(upDownFileParams);
         var prevAmountDone = 0;
+        ee.activeTransfers++;
         ee.emit('fileDownloadStart', fullPath, fullKey);
         downloader.on('error', handleError);
         downloader.on('progress', function() {
@@ -1134,7 +1137,9 @@ function syncDir(self, params, directionIsToS3) {
           ee.emit('progress');
         });
         downloader.on('end', function() {
+          ee.activeTransfers--;
           ee.emit('fileDownloadEnd', fullPath, fullKey);
+          ee.emit('progress');
           checkDoMoreWork();
         });
       }
@@ -1179,6 +1184,7 @@ function syncDir(self, params, directionIsToS3) {
         var uploader = self.uploadFile(upDownFileParams);
         var prevAmountDone = 0;
         var prevAmountTotal = localFileStat.size;
+        ee.activeTransfers++;
         ee.emit('fileUploadStart', fullPath, fullKey);
         uploader.on('error', handleError);
         uploader.on('progress', function() {
@@ -1194,7 +1200,9 @@ function syncDir(self, params, directionIsToS3) {
           ee.emit('progress');
         });
         uploader.on('end', function() {
+          ee.activeTransfers--;
           ee.emit('fileUploadEnd', fullPath, fullKey);
+          ee.emit('progress');
           checkDoMoreWork();
         });
       }

--- a/test/test.js
+++ b/test/test.js
@@ -456,7 +456,7 @@ describe("s3", function () {
   });
 
   it("uploads folder with lots of files", function(done) {
-    createFolderOfFiles(tempManyFilesDir, 100, 100 * 1024, function() {
+    createFolderOfFiles(tempManyFilesDir, 10, 100 * 1024, function() {
       var client = createClient();
       var params = {
         localDir: tempManyFilesDir,
@@ -480,7 +480,7 @@ describe("s3", function () {
         var finder = client.listObjects(params);
         var found = false;
         finder.on('data', function(data) {
-          assert.strictEqual(data.Contents.length, 100);
+          assert.strictEqual(data.Contents.length, 10);
           found = true;
         });
         finder.on('end', function() {


### PR DESCRIPTION
Currently `uploadDir` method fails because it doesn't wait for individual upload steams to end before emitting the `end` event. It does wait until the total data sent reaches the expected amount but this happens before the files are reliably on S3 and the `end` event for each file occurs.

This pull request adds a `activeTransfer` counter that increments with a new file being uploaded and decrements when the file has an `end` event.

It also adds a test that fails on the current master but passes with these changes. Tested on node `v0.10.35`, `v0.12.7`, `v4.3.2`, and `v5.7.1`.