### PR TITLE
aws-sdk updated 

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "ncp": "~1.0.1"
   },
   "dependencies": {
-    "aws-sdk": "~2.2.16",
+    "aws-sdk": "~2.4.9",
     "fd-slicer": "~1.0.0",
     "findit2": "~2.2.3",
     "graceful-fs": "~4.1.4",


### PR DESCRIPTION
fixes for Non-file stream objects are not supported with SigV4 in AWS.S3