### PR TITLE
Support KMS Encryption

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -137,6 +137,7 @@ Client.prototype.uploadFile = function(params) {
     var defaultContentType = params.defaultContentType || 'application/octet-stream';
     s3Params.ContentType = mime.lookup(localFile, defaultContentType);
   }
+  var sse = s3Params.ServerSideEncryption;
   var fatalError = false;
   var localFileSlicer = null;
   var parts = [];
@@ -222,10 +223,7 @@ Client.prototype.uploadFile = function(params) {
         Key: encodeSpecialCharacters(s3Params.Key),
         SSECustomerAlgorithm: s3Params.SSECustomerAlgorithm,
         SSECustomerKey: s3Params.SSECustomerKey,
-        SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5,        
-        ServerSideEncryption: s3Params.ServerSideEncryption,
-        SSEKMSKeyId: s3Params.SSEKMSKeyId,
-        Metadata: s3Params.Metadata
+        SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5
       };
       queueAllParts(data.UploadId, multipartUploadSize);
     });
@@ -318,7 +316,7 @@ Client.prototype.uploadFile = function(params) {
           }
           pend.wait(function() {
             if (fatalError) return;
-            if (s3Params.ServerSideEncryption !== 'aws:kms') {
+            if (sse !== 'aws:kms') {
               if (!compareMultipartETag(data.ETag, multipartETag)) {
                 errorOccurred = true;
                 uploader.progressAmount -= overallDelta;
@@ -416,7 +414,7 @@ Client.prototype.uploadFile = function(params) {
         }
         pend.wait(function() {
           if (fatalError) return;
-          if (s3Params.ServerSideEncryption !== 'aws:kms') {
+          if (sse !== 'aws:kms') {
             if (!compareMultipartETag(data.ETag, localFileStat.multipartETag)) {
               cb(new Error("ETag does not match MD5 checksum"));
               return;

--- a/lib/index.js
+++ b/lib/index.js
@@ -511,10 +511,11 @@ Client.prototype.downloadFile = function(params) {
               handleError(new Error("Downloaded size does not match Content-Length"));
               return;
             }
-            console.log('DEBUG headers', headers);
-            if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
-              handleError(new Error("ETag does not match MD5 checksum"));
-              return;
+            if (headers['x-amz-server-side-encryption'] !== 'aws:kms' ) {
+              if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
+                handleError(new Error("ETag does not match MD5 checksum"));
+                return;
+              }
             }
             cb();
           });
@@ -830,9 +831,11 @@ Client.prototype.downloadBuffer = function(s3Params) {
             handleError(new Error("Downloaded size does not match Content-Length"));
             return;
           }
-          if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
-            handleError(new Error("ETag does not match MD5 checksum"));
-            return;
+          if (headers['x-amz-server-side-encryption'] !== 'aws:kms' ) {
+            if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
+              handleError(new Error("ETag does not match MD5 checksum"));
+              return;
+            }
           }
           cb();
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,9 +220,9 @@ Client.prototype.uploadFile = function(params) {
       s3Params = {
         Bucket: s3Params.Bucket,
         Key: encodeSpecialCharacters(s3Params.Key),
-        SSECustomerAlgorithm: s3Params.SSECustomerAlgorithm,
-        SSECustomerKey: s3Params.SSECustomerKey,
-        SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5,
+        ServerSideEncryption: s3Params.ServerSideEncryption,
+        SSEKMSKeyId: s3Params.SSEKMSKeyId,
+        Metadata: s3Params.Metadata
       };
       queueAllParts(data.UploadId, multipartUploadSize);
     });
@@ -315,11 +315,13 @@ Client.prototype.uploadFile = function(params) {
           }
           pend.wait(function() {
             if (fatalError) return;
-            if (!compareMultipartETag(data.ETag, multipartETag)) {
-              errorOccurred = true;
-              uploader.progressAmount -= overallDelta;
-              cb(new Error("ETag does not match MD5 checksum"));
-              return;
+            if (!s3Params.ServerSideEncryption) {
+              if (!compareMultipartETag(data.ETag, multipartETag)) {
+                errorOccurred = true;
+                uploader.progressAmount -= overallDelta;
+                cb(new Error("ETag does not match MD5 checksum"));
+                return;
+              }
             }
             part.ETag = data.ETag;
             cb(null, data);
@@ -411,9 +413,11 @@ Client.prototype.uploadFile = function(params) {
         }
         pend.wait(function() {
           if (fatalError) return;
-          if (!compareMultipartETag(data.ETag, localFileStat.multipartETag)) {
-            cb(new Error("ETag does not match MD5 checksum"));
-            return;
+          if (s3Params.ServerSideEncryption !== 'aws:kms') {
+            if (!compareMultipartETag(data.ETag, localFileStat.multipartETag)) {
+              cb(new Error("ETag does not match MD5 checksum"));
+              return;
+            }
           }
           cb(null, data);
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -315,7 +315,7 @@ Client.prototype.uploadFile = function(params) {
           }
           pend.wait(function() {
             if (fatalError) return;
-            if (!s3Params.ServerSideEncryption) {
+            if (s3Params.ServerSideEncryption !== 'aws:kms') {
               if (!compareMultipartETag(data.ETag, multipartETag)) {
                 errorOccurred = true;
                 uploader.progressAmount -= overallDelta;

--- a/lib/index.js
+++ b/lib/index.js
@@ -220,6 +220,9 @@ Client.prototype.uploadFile = function(params) {
       s3Params = {
         Bucket: s3Params.Bucket,
         Key: encodeSpecialCharacters(s3Params.Key),
+        SSECustomerAlgorithm: s3Params.SSECustomerAlgorithm,
+        SSECustomerKey: s3Params.SSECustomerKey,
+        SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5,        
         ServerSideEncryption: s3Params.ServerSideEncryption,
         SSEKMSKeyId: s3Params.SSEKMSKeyId,
         Metadata: s3Params.Metadata

--- a/lib/index.js
+++ b/lib/index.js
@@ -511,6 +511,7 @@ Client.prototype.downloadFile = function(params) {
               handleError(new Error("Downloaded size does not match Content-Length"));
               return;
             }
+            console.log('DEBUG headers', headers);
             if (eTagCount === 1 && !multipartETag.anyMatch(eTag)) {
               handleError(new Error("ETag does not match MD5 checksum"));
               return;


### PR DESCRIPTION
- Add extra parameters for Metadata and supporting AWS KMS
- Remove ETag comparisons for KMS, as KMS ETag is no longer MD5 of plaintext file: http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingKMSEncryption.html

