### PR TITLE
remove duplicate encoding in multipart upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -219,7 +219,7 @@ Client.prototype.uploadFile = function(params) {
       uploader.emit('data', data);
       s3Params = {
         Bucket: s3Params.Bucket,
-        Key: encodeSpecialCharacters(s3Params.Key),
+        Key: s3Params.Key,
         SSECustomerAlgorithm: s3Params.SSECustomerAlgorithm,
         SSECustomerKey: s3Params.SSECustomerKey,
         SSECustomerKeyMD5: s3Params.SSECustomerKeyMD5,


### PR DESCRIPTION
remove encoding of s3 key when you try to upload in multipart because it cause duplicate encoding since aws also does encoding on the key.
you can also see that when you upload file not in multipart you never do encoding on the key

right now it causes an error if you try to sync file called "example 1.png" in multi part.
because it does encoding on the key to this "example%201.png" and the aws does encoding again i guess
and the key changed to "example%251.png" which not exist.

thanks