### PR TITLE
Allow s3 'folder objects' and fix #54

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1111,7 +1111,7 @@ function syncDir(self, params, directionIsToS3) {
       s3ObjectCursor += 1;
       setImmediate(checkDoMoreWork);
       var fullPath = path.join(localDir, toNativeSep(s3Object.key));
-      
+
       if (getS3Params) {
         getS3Params(fullPath, s3Object, haveS3Params);
       } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -427,8 +427,8 @@ Client.prototype.downloadFile = function(params) {
   var downloader = new EventEmitter();
   var localFile = params.localFile;
   var s3Params = extend({}, params.s3Params);
-
-  var dirPath = path.dirname(localFile);
+  var dirPath = (localFile.match(/\/$/))?localFile:path.dirname(localFile);
+  console.log('downloadFile', dirPath);
   downloader.progressAmount = 0;
   mkdirp(dirPath, function(err) {
     if (err) {
@@ -1018,6 +1018,9 @@ function syncDir(self, params, directionIsToS3) {
       return;
     }
 
+    console.log('localpath=', (localFileStat)?localFileStat.path:'null', ' locals3path=', (localFileStat)?localFileStat.s3Path:'null', ' s3Object.key=', (s3Object)?s3Object.key:'null');
+
+
     // special case for directories when deleteRemoved is true and we're
     // downloading a dir from S3. We don't add directories to the list
     // unless this case is true, so we assert that fact here.
@@ -1025,12 +1028,42 @@ function syncDir(self, params, directionIsToS3) {
       assert.ok(!directionIsToS3);
       assert.ok(deleteRemoved);
 
-      localFileCursor += 1;
-      setImmediate(checkDoMoreWork);
-
-      if (!s3Object || s3Object.key.indexOf(localFileStat.s3Path) !== 0) {
-        deleteLocalDir();
+      if (!s3Object) {
+        console.log('!!!  !s3Object');
+        deleteLocalDir(); // no more s3 objects
       }
+      else if (localFileStat.s3Path > s3Object.key){
+        downloadS3Object(); // previous item, download it.
+      }
+      else if (s3Object.key.indexOf(localFileStat.s3Path) !== 0 ){  // starts with this folder name
+        console.log('!!!  s3Object.key.indexOf(localFileStat.s3Path) !== 0');
+        deleteLocalDir();
+      } else if (localFileStat.s3Path === s3Object.key) { // same folder (don't need to download it.)
+        skipThisOne();
+      } else if (s3Object.key.indexOf(localFileStat.s3Path) === 0){
+        localFileCursor += 1;
+        setImmediate(checkDoMoreWork); // skip this, just a local folder
+      }
+
+
+      // different cases
+
+      // a directory, with no remote equivalent (has been deleted)
+      // local=/xml remote=undefined <-- at the end.       **
+      // local=/xml remote=/yml/head.hbs <!-- ahead by one.   ****   
+      // local=/xml remote=/xnomething <-- next in line
+      // local=/xml remote=/zml <!-- next in line
+      
+      // --> delete it
+
+      // a directory with a remove object equivalent
+      // local=/xml remote=/xml
+      // --> ignore it.
+
+      // a directory, with no remote object equivalent (but a file that begins with the same name)
+      // local=/xml remote=/xml/something.hbs
+      // --> do nothing just pass on..
+
       return;
     }
 
@@ -1069,8 +1102,12 @@ function syncDir(self, params, directionIsToS3) {
     }
 
     function deleteLocalDir() {
-      var fullPath = path.join(localDir, localFileStat.path);
+      localFileCursor += 1;
+      setImmediate(checkDoMoreWork);
+      if (!deleteRemoved) return;
       ee.deleteTotal += 1;
+      var fullPath = path.join(localDir, localFileStat.path);
+      console.log('removing directory', fullPath);
       rimraf(fullPath, function(err) {
         if (fatalError) return;
         if (err && err.code !== 'ENOENT') return handleError(err);
@@ -1086,6 +1123,7 @@ function syncDir(self, params, directionIsToS3) {
       if (!deleteRemoved) return;
       ee.deleteTotal += 1;
       var fullPath = path.join(localDir, localFileStat.path);
+      console.log('deleting:'+fullPath);
       fs.unlink(fullPath, function(err) {
         if (fatalError) return;
         if (err && err.code !== 'ENOENT') return handleError(err);
@@ -1099,6 +1137,8 @@ function syncDir(self, params, directionIsToS3) {
       s3ObjectCursor += 1;
       setImmediate(checkDoMoreWork);
       var fullPath = path.join(localDir, toNativeSep(s3Object.key));
+
+      console.log('downloadS3Object', fullPath);
 
       if (getS3Params) {
         getS3Params(fullPath, s3Object, haveS3Params);
@@ -1146,6 +1186,7 @@ function syncDir(self, params, directionIsToS3) {
     }
 
     function skipThisOne() {
+      console.log('skipThisOne localFile=' + allLocalFiles[localFileCursor].path + ' s3Object=' +allS3Objects[s3ObjectCursor].key);
       s3ObjectCursor += 1;
       localFileCursor += 1;
       setImmediate(checkDoMoreWork);
@@ -1237,6 +1278,7 @@ function syncDir(self, params, directionIsToS3) {
       ee.emit('progress');
       data.Contents.forEach(function(object) {
         object.key = object.Key.substring(prefix.length);
+        console.log('s3Object=', object.key);
         allS3Objects.push(object);
       });
       checkDoMoreWork();
@@ -1266,6 +1308,10 @@ function syncDir(self, params, directionIsToS3) {
           return 0;
         }
       });
+
+      for (var i = 0; i < allLocalFiles.length; i++) {
+        console.log('localFile=' + allLocalFiles[i].path + ', s3Path=' + allLocalFiles[i].s3Path);
+      }
       startComputingMd5Sums();
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1111,6 +1111,7 @@ function syncDir(self, params, directionIsToS3) {
       s3ObjectCursor += 1;
       setImmediate(checkDoMoreWork);
       var fullPath = path.join(localDir, toNativeSep(s3Object.key));
+      
       if (getS3Params) {
         getS3Params(fullPath, s3Object, haveS3Params);
       } else {
@@ -1277,7 +1278,6 @@ function syncDir(self, params, directionIsToS3) {
           return 0;
         }
       });
-
       startComputingMd5Sums();
     });
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1249,7 +1249,9 @@ function syncDir(self, params, directionIsToS3) {
       ee.emit('progress');
       data.Contents.forEach(function(object) {
         object.key = object.Key.substring(prefix.length);
-        allS3Objects.push(object);
+        if (object.key != ""){
+          allS3Objects.push(object);
+        }
       });
       checkDoMoreWork();
     });

--- a/lib/index.js
+++ b/lib/index.js
@@ -428,7 +428,6 @@ Client.prototype.downloadFile = function(params) {
   var localFile = params.localFile;
   var s3Params = extend({}, params.s3Params);
   var dirPath = (localFile.match(/\/$/))?localFile:path.dirname(localFile);
-  console.log('downloadFile', dirPath);
   downloader.progressAmount = 0;
   mkdirp(dirPath, function(err) {
     if (err) {
@@ -1018,8 +1017,6 @@ function syncDir(self, params, directionIsToS3) {
       return;
     }
 
-    console.log('localpath=', (localFileStat)?localFileStat.path:'null', ' locals3path=', (localFileStat)?localFileStat.s3Path:'null', ' s3Object.key=', (s3Object)?s3Object.key:'null');
-
 
     // special case for directories when deleteRemoved is true and we're
     // downloading a dir from S3. We don't add directories to the list
@@ -1029,14 +1026,12 @@ function syncDir(self, params, directionIsToS3) {
       assert.ok(deleteRemoved);
 
       if (!s3Object) {
-        console.log('!!!  !s3Object');
         deleteLocalDir(); // no more s3 objects
       }
       else if (localFileStat.s3Path > s3Object.key){
         downloadS3Object(); // previous item, download it.
       }
       else if (s3Object.key.indexOf(localFileStat.s3Path) !== 0 ){  // starts with this folder name
-        console.log('!!!  s3Object.key.indexOf(localFileStat.s3Path) !== 0');
         deleteLocalDir();
       } else if (localFileStat.s3Path === s3Object.key) { // same folder (don't need to download it.)
         skipThisOne();
@@ -1044,25 +1039,6 @@ function syncDir(self, params, directionIsToS3) {
         localFileCursor += 1;
         setImmediate(checkDoMoreWork); // skip this, just a local folder
       }
-
-
-      // different cases
-
-      // a directory, with no remote equivalent (has been deleted)
-      // local=/xml remote=undefined <-- at the end.       **
-      // local=/xml remote=/yml/head.hbs <!-- ahead by one.   ****   
-      // local=/xml remote=/xnomething <-- next in line
-      // local=/xml remote=/zml <!-- next in line
-      
-      // --> delete it
-
-      // a directory with a remove object equivalent
-      // local=/xml remote=/xml
-      // --> ignore it.
-
-      // a directory, with no remote object equivalent (but a file that begins with the same name)
-      // local=/xml remote=/xml/something.hbs
-      // --> do nothing just pass on..
 
       return;
     }
@@ -1107,7 +1083,6 @@ function syncDir(self, params, directionIsToS3) {
       if (!deleteRemoved) return;
       ee.deleteTotal += 1;
       var fullPath = path.join(localDir, localFileStat.path);
-      console.log('removing directory', fullPath);
       rimraf(fullPath, function(err) {
         if (fatalError) return;
         if (err && err.code !== 'ENOENT') return handleError(err);
@@ -1123,7 +1098,6 @@ function syncDir(self, params, directionIsToS3) {
       if (!deleteRemoved) return;
       ee.deleteTotal += 1;
       var fullPath = path.join(localDir, localFileStat.path);
-      console.log('deleting:'+fullPath);
       fs.unlink(fullPath, function(err) {
         if (fatalError) return;
         if (err && err.code !== 'ENOENT') return handleError(err);
@@ -1137,9 +1111,6 @@ function syncDir(self, params, directionIsToS3) {
       s3ObjectCursor += 1;
       setImmediate(checkDoMoreWork);
       var fullPath = path.join(localDir, toNativeSep(s3Object.key));
-
-      console.log('downloadS3Object', fullPath);
-
       if (getS3Params) {
         getS3Params(fullPath, s3Object, haveS3Params);
       } else {
@@ -1186,7 +1157,6 @@ function syncDir(self, params, directionIsToS3) {
     }
 
     function skipThisOne() {
-      console.log('skipThisOne localFile=' + allLocalFiles[localFileCursor].path + ' s3Object=' +allS3Objects[s3ObjectCursor].key);
       s3ObjectCursor += 1;
       localFileCursor += 1;
       setImmediate(checkDoMoreWork);
@@ -1278,7 +1248,6 @@ function syncDir(self, params, directionIsToS3) {
       ee.emit('progress');
       data.Contents.forEach(function(object) {
         object.key = object.Key.substring(prefix.length);
-        console.log('s3Object=', object.key);
         allS3Objects.push(object);
       });
       checkDoMoreWork();
@@ -1309,9 +1278,6 @@ function syncDir(self, params, directionIsToS3) {
         }
       });
 
-      for (var i = 0; i < allLocalFiles.length; i++) {
-        console.log('localFile=' + allLocalFiles[i].path + ', s3Path=' + allLocalFiles[i].s3Path);
-      }
       startComputingMd5Sums();
     });
   }


### PR DESCRIPTION
fixes #54 . 
During investigation of issue #54 I discovered folders were being deleted because of incorrect logic in the folder handling clause (download sync only). 
Also S3 can now have 'empty' folder objects. (when created via the AWS console, or Cyberduck interfaces). Updated the logic to handle the local creation of remote 'empty' folders

