### PR TITLE
Added cancel funcionality to downloadFile

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -438,6 +438,12 @@ Client.prototype.downloadFile = function(params) {
 
     doWithRetry(doDownloadWithPend, self.s3RetryCount, self.s3RetryDelay, function(err) {
       if (err) {
+
+        // if request was aborted, emit `cancelled` event
+        if(err.code === 'RequestAbortedError') {
+          return downloader.emit('cancelled');
+        }
+
         downloader.emit('error', err);
         return;
       }
@@ -460,6 +466,8 @@ Client.prototype.downloadFile = function(params) {
     var request = self.s3.getObject(s3Params);
     var errorOccurred = false;
     var hashCheckPend = new Pend();
+
+    downloader.on('cancel', () => request.abort());
 
     request.on('httpHeaders', function(statusCode, headers, resp) {
       if (statusCode >= 300) {


### PR DESCRIPTION
Added the ability to cancel a download.

You can use: `downloader.emit('cancel')` to cancel the download, and `downloader.on('cancelled')` to check that it was cancelled.

```
const downloader = client.downloadFile(params);

downloader.on('error', function(err) {
  console.error('unable to download:', err.stack);
});

downloader.on('cancelled', function() {
  console.log('Download was cancelled:');
});

downloader.on('progress', function() {
  console.log('progress', downloader.progressAmount, downloader.progressTotal);
});

downloader.on('end', function() {
  console.log('done downloading');
});

setTimeout(() => {
  downloader.emit('cancel');
}, 2000);
```

I can change the the API to provide a `.cancel` method, but since `downloader` is an `EventEmitter` using `.emit` seemed like a good idea.
